### PR TITLE
Change io-depth to iodepth

### DIFF
--- a/UG9/en/latency.adoc
+++ b/UG9/en/latency.adoc
@@ -100,7 +100,7 @@ numbers. With that kind of trick DRBD does offer you 100000 IOPs, too!
 
 So, please don't shy away from measuring serialized, single-threaded latency. 
 If you want lots of IOPs, run the `fio` utility with `threads=8` and an 
-`io-depth=16`, or some similar settings... But please keep in mind that these
+`iodepth=16`, or some similar settings... But please keep in mind that these
 number will not have any meaning to your setup, unless you're driving 
 a database with many tens or hundreds of client connections active at the same 
 time.


### PR DESCRIPTION
The current fio uses `iodepth` and not `io-depth` as per https://linux.die.net/man/1/fio

I know this is a very minor change but I'm currently investigating latency / IOPS issues on our DRBD setup with fio and noticed this. Sorry for nitpicking :)

Thanks for all the good work you do!