### PR TITLE
ja: fix Japanese monospace is garbled, use left align.

### DIFF
--- a/stylesheets/pdf-style-ja.yml
+++ b/stylesheets/pdf-style-ja.yml
@@ -43,6 +43,8 @@ title-page:
 base:
   font_size: 10
   font_family: LINBIT
+  align: left
+
 ## Formatting for Abstract (here as example)
 abstract:
   font_size: $base_font_size
@@ -119,3 +121,5 @@ footer:
       content:
     left:
       content:
+literal:
+  font_family: LINBIT


### PR DESCRIPTION
I fixed the issue Japanese monospace is garbled, also use left align.
Could you please merge this if it is ok?
